### PR TITLE
fix for xarray >=0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## [Unreleased](https://github.com/ParaConUK/advtraj/tree/HEAD)
+
+[Full Changelog](https://github.com/ParaConUK/advtraj/compare/v0.4.0...HEAD)
+
+
+*maintenance*
+
+- fix to support xarray version `>=0.19.0`
+  [\#5](https://github.com/ParaConUK/advtraj/pull/5) @leifdenby
+
+
+## [v0.4.0](https://github.com/ParaConUK/advtraj/tree/v0.4.0)
+
+[Full Changelog](https://github.com/ParaConUK/advtraj/compare/v0.3.0...v0.4.0)
+
+
+## [v0.3.0](https://github.com/ParaConUK/advtraj/tree/v0.3.0)
+
+[Full Changelog](https://github.com/ParaConUK/advtraj/compare/c5e3ba670...v0.3.0)

--- a/advtraj/utils/grid_mapping.py
+++ b/advtraj/utils/grid_mapping.py
@@ -168,9 +168,9 @@ def grid_locations_to_position_scalars(ds_grid, ds_pts=None):
         k_ = (ds_pts.z - ds_grid.z.min()) / dz
 
         ds_indecies = ds_pts.copy()
-        ds_indecies["i"] = ds_pts.x.dims, i_
-        ds_indecies["j"] = ds_pts.y.dims, j_
-        ds_indecies["k"] = ds_pts.z.dims, k_
+        ds_indecies["i"] = i_
+        ds_indecies["j"] = j_
+        ds_indecies["k"] = k_
 
     xy_periodic = ds_grid.xy_periodic
 


### PR DESCRIPTION
xarray>=0.19.0 deprecates assigning a data-array into a dataset while
providing the dimension names, quote:

> "Completed deprecation of passing an xarray.DataArray to Variable() -
will now raise a TypeError (PR5630)"

https://xarray.pydata.org/en/stable/whats-new.html?highlight=colormap#v0-19-0-23-july-2021

This commit fixes the issue