### PR TITLE
Support for MONC model grid.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,8 @@
 [Full Changelog](https://github.com/ParaConUK/advtraj/compare/v0.4.0...HEAD)
 
 *Support for MONC*
-Primarily changes to support the MONC grid. This has:
-- First u point at first p point + dx/2, so it makes sense to have p[0] at x=0.
-- First v point at first p point + dy/2, so it makes sense to have p[0] at y=0.
-- Virtual p point at z = -dz/2.
-
-Main changes are in creating synthetic data fro testing.
+Add support for MONC grid by implementing its c-grid configuration for where
+the position scalars are stored.
 
 *maintenance*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [Full Changelog](https://github.com/ParaConUK/advtraj/compare/v0.4.0...HEAD)
 
+*Support for MONC*
+Primarily changes to support the MONC grid. This has:
+- First u point at first p point + dx/2, so it makes sense to have p[0] at x=0.
+- First v point at first p point + dy/2, so it makes sense to have p[0] at y=0.
+- Virtual p point at z = -dz/2.
+
+Main changes are in creating synthetic data fro testing.
 
 *maintenance*
 

--- a/advtraj/utils/grid.py
+++ b/advtraj/utils/grid.py
@@ -1,3 +1,27 @@
+"""
+    grid.py
+
+    Utilities to deal with grid wrapping etc.
+
+    Currently, caters for the following grid styles:
+
+    "cell_centred"
+    - p-point (cell centre) p[0, 0, 0]] at x = dx/2, y = dy/2, z = dz/2.
+    - u-point (cell face) u[0, 0, 0] at p[0, 0, 0] - dx/2, i.e. x = 0.
+    - v-point (cell face) v[0, 0, 0] at p[0, 0, 0] - dy/2, i.e. y = 0.
+    - w-point (cell face) w[0, 0, 0] at p[0, 0, 0] - dz/2, i.e. z = 0.
+    - Virtual p point at z = -dz/2.
+
+    "monc"
+    - Virtual p points at z = -dz/2 so:
+    - p-point (cell centre) p[0, 0, 0]] at x = dx/2, y = dy/2, z = -dz/2.
+    - u-point (cell face) u[0, 0, 0] at p[0, 0, 0] + dx/2, i.e. x = dx.
+    - v-point (cell face) v[0, 0, 0] at p[0, 0, 0] + dy/2, i.e. y = dy.
+    - w-point (cell face) w[0, 0, 0] at p[0, 0, 0] + dz/2, i.e. z = 0.
+
+    ""
+    - All points [0, 0, 0] at x = 0, y = 0, z = 0.
+"""
 import warnings
 
 import numpy as np

--- a/advtraj/utils/grid.py
+++ b/advtraj/utils/grid.py
@@ -15,6 +15,7 @@ def wrap_posn(x, x_min, x_max):
     N_wrap = np.where(r >= 0.0, r.astype(int), r.astype(int) - 1.0)
 
     x_wrapped = x - lx * N_wrap
+
     return x_wrapped
 
 
@@ -62,9 +63,10 @@ def wrap_periodic_grid_coords(
         if c in cell_centered_coords:
             x_min -= dx / 2.0
             x_max += dx / 2.0
+        else:
+            x_max += dx
 
         ds_posn_copy[c].values = wrap_posn(
             ds_posn_copy[c].values, x_min=x_min, x_max=x_max
         )
-
     return ds_posn_copy

--- a/advtraj/utils/grid_mapping.py
+++ b/advtraj/utils/grid_mapping.py
@@ -17,6 +17,8 @@ def _calculate_phase(vr, vi, n_grid):
     correspond to the left-most of the domain). To support staggered variables
     this should be adapted.
 
+    Note: assumes zeroth grid point has zero phase.
+
     Args:
         vr, vi  : real and imaginary parts of complex location.
         n_grid  : grid size
@@ -40,7 +42,9 @@ def _estimate_dim_initial_grid_indecies(ds_position_scalars, dim, xy_periodic, n
     """
     Using the position scalars in `ds_position_scalars` estimate the grid
     locations (in indecies) where the fluid was initially located when the
-    position scalars were initiated
+    position scalars were initiated.
+
+    Note: assumes zeroth grid point has zero phase.
     """
     if dim in ["x", "y"] and xy_periodic:
         da_vr = ds_position_scalars[f"traj_tracer_{dim}r"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: Scientific/Engineering
 
 [options]

--- a/tests/test_grid_utils.py
+++ b/tests/test_grid_utils.py
@@ -51,6 +51,8 @@ def test_cyclic_coord_wrapping(grid_style):
 
     if grid_style == "cell_centered":
         cell_centered_coords = ["x", "y", "z"]
+    elif grid_style == "monc":
+        cell_centered_coords = ["x", "y"]
     else:
         cell_centered_coords = []
 

--- a/tests/test_grid_utils.py
+++ b/tests/test_grid_utils.py
@@ -14,12 +14,12 @@ def test_wrap_coord_posn():
     np.testing.assert_allclose(x_wrapped_true, x_wrapped)
 
 
-@pytest.mark.parametrize("cell_centered", [True, False])
-def test_cyclic_coord_wrapping(cell_centered):
+@pytest.mark.parametrize("grid_style", ["cell_centered", "monc", ""])
+def test_cyclic_coord_wrapping(grid_style):
     dx = 25.0
     dL = (dx, dx, dx)
     L = (1.0e3, 1.0e3, 500.0)
-    ds_grid = create_uniform_grid(dL=dL, L=L, cell_centered=cell_centered)
+    ds_grid = create_uniform_grid(dL=dL, L=L, grid_style=grid_style)
 
     Lx_c, Ly_c, Lz_c = [L[0] / 2.0, L[1] / 2.0, L[2] / 2.0]
     Lx, Ly, Lz = L
@@ -49,7 +49,7 @@ def test_cyclic_coord_wrapping(cell_centered):
     def _pt_from_dataset(ds_pt):
         return np.array([ds_pt[v] for v in ["x", "y", "z"]])
 
-    if cell_centered:
+    if grid_style == "cell_centered":
         cell_centered_coords = ["x", "y", "z"]
     else:
         cell_centered_coords = []

--- a/tests/test_synthetic_data.py
+++ b/tests/test_synthetic_data.py
@@ -10,7 +10,7 @@ def _advect_fields(ds_scalars, u, v, dt):
     Perform poor-mans advection by rolling all variables in `ds_scalars` by a
     finite number of grid positions, requiring that the time-increment `dt`
     causes exactly grid-aligned shifts using grid resolution `dx_grid`,
-    `dy_grid` with x- and y-velocity (`u`, `v`)
+    `dy_grid` with x- and y-velocity (`u`, `v`).
     """
     dx_grid = ds_scalars.x.dx
     dy_grid = ds_scalars.y.dy

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -66,6 +66,8 @@ def create_uniform_grid(dL, L, grid_style="cell_centred"):
     """
     Create a grid with uniform resolution in x,y and z with domain spanning
     [0,0,0] to `L` with grid resolution `dL`
+
+
     """
     Lx, Ly, Lz = L
     dx, dy, dz = dL
@@ -77,8 +79,8 @@ def create_uniform_grid(dL, L, grid_style="cell_centred"):
         z_ = crange(dz / 2.0, Lz - dz / 2.0, dz)
     elif grid_style == "monc":
         # create wrapped positions starting at 0.
-        x_ = crange(0, Lx - dx, dx)
-        y_ = crange(0, Ly - dy, dy)
+        x_ = crange(dx / 2.0, Lx - dx / 2.0, dx)
+        y_ = crange(dy / 2.0, Ly - dy / 2.0, dy)
         # create cell-centred including virtual point below surface.
         z_ = crange(-dz / 2.0, Lz - dz / 2.0, dz)
     else:


### PR DESCRIPTION
*Support for MONC*
Primarily changes to support the MONC grid. This has:
- First u point at first p point + dx/2, so it makes sense to have p[0] at x=0.
- First v point at first p point + dy/2, so it makes sense to have p[0] at y=0.
- Virtual p point at z = -dz/2.

Main changes are in creating synthetic data for testing.
