### PR TITLE
Add test data and tests for UCLALES interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,6 @@ test_data
 .*.sw*
 
 source/
+
+# test data
+uclales.advtraj.testdata.tar.gz

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ dev =
   ipdb
   pre-commit
   ipython
+  requests
 
 
 [tool:pytest]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,42 @@
+import os
+import tarfile
+import tempfile
+from pathlib import Path
+
+import pytest
+import requests
+
+TESTDATA_URL = "http://gws-access.jasmin.ac.uk/public/eurec4auk/testdata/uclales.advtraj.testdata.tar.gz"  # noqa
+
+if os.environ.get("ADVTRAJ_TESTDATA_DIR", None):
+    TESTDATA_DIR = Path(os.environ["ADVTRAJ_TESTDATA_DIR"])
+else:
+    tempdir = tempfile.TemporaryDirectory()
+    TESTDATA_DIR = Path(tempdir.name)
+
+
+def _download_testdata():
+    fhtar = tempfile.NamedTemporaryFile(delete=False, suffix=".tar.gz")
+
+    r = requests.get(TESTDATA_URL)
+    fhtar.write(r.content)
+    fhtar.close()
+
+    tarfile.open(fhtar.name, "r:gz").extractall(TESTDATA_DIR)
+
+
+def ensure_testdata_available():
+    if not TESTDATA_DIR.exists():
+        raise Exception(f"Couldn't find test-data directory {TESTDATA_DIR}")
+    # Download testdata if it is not there yet
+    if len(list(TESTDATA_DIR.glob("**/*.nc"))) == 0:
+        print("Downloading testdata...")
+        _download_testdata()
+
+
+@pytest.fixture
+def uclales_testdata_path():
+    ensure_testdata_available()
+    p_root = Path(TESTDATA_DIR)
+
+    return p_root

--- a/tests/data/uclales/NAMELIST
+++ b/tests/data/uclales/NAMELIST
@@ -1,0 +1,43 @@
+ &model
+  nxp = 36
+  nyp = 36
+  nzp = 70
+  deltax  =100.
+  deltay  =100.
+  deltaz  = 40.
+  dzmax   = 10.
+  dzrat   = 1.0
+  dtlong  = 4.
+  timmax =  2400.
+  runtype= 'INITIAL'
+  filprf = 'rico'
+  hfilin = 'rico.rst'
+  savg_intvl=120.
+  ssam_intvl=  30.
+  frqhis = 480.
+  frqanl = 120.
+  level  = 3
+  CCN    = 70.e6
+  corflg = .true.
+  cntlat = 18.
+  th00   = 299.8
+  sst    = 299.8
+  isfctyp=3
+  iradtyp=1
+  zrough = 0.001229
+  dthcon = 0.001094
+  drtcon = 0.001133
+  ps =    1015.4,  740., 3260., 4000.,
+  ts =     297.9, 297.9, 312.6644, 317.0,
+  rts=      16.0,  13.8,   2.4,   1.8,
+  us =      -9.9, -8.42,  -3.38, -1.9,
+  vs =      -3.8,  -3.8,  -3.8,  -3.8,
+  vmean = -4.
+  umean = -5.
+  case_name='rico'
+  lsvarflg=.false.
+  div=0.00000000
+
+  ! turn on optional features
+  ladvtrc = .true.  ! advected position tracers
+ /

--- a/tests/data/uclales/README.md
+++ b/tests/data/uclales/README.md
@@ -1,0 +1,65 @@
+# Steps to reproduce
+
+```bash
+git clone https://github.com/leifdenby/uclales
+cd uclales
+git checkout advective-trajectories
+mamba env create -f .github/ci_deps/Linux.yml -n uclales
+conda activate uclales
+cmake -DMPI=TRUE .
+make -j4
+mkdir run
+cd run
+# create NAMELIST, see below
+mpiexec -np 4 ../
+tar zcvf uclales.advtraj.tesdata.tar.gz NAMELIST rico.????????.nc
+```
+
+
+NAMELIST:
+```
+&model
+ nxp = 36
+ nyp = 36
+ nzp = 70
+ nxpart = .true.
+ deltax  =100.
+ deltay  =100.
+ deltaz  = 40.
+ dzmax   = 10.
+ dzrat   = 1.0
+ dtlong  = 4.
+ timmax =  240.
+ runtype= 'INITIAL'
+ filprf = 'rico'
+ hfilin = 'rico.rst'
+ savg_intvl=120.
+ ssam_intvl=  30.
+ frqhis = 60.
+ frqanl = 120.
+ level  = 3
+ CCN    = 70.e6
+ corflg = .true.
+ cntlat = 18.
+ th00   = 299.8
+ sst    = 299.8
+ isfctyp=3
+ iradtyp=1
+ zrough = 0.001229
+ dthcon = 0.001094
+ drtcon = 0.001133
+ ps =    1015.4,  740., 3260., 4000.,
+ ts =     297.9, 297.9, 312.6644, 317.0,
+ rts=      16.0,  13.8,   2.4,   1.8,
+ us =      -9.9, -8.42,  -3.38, -1.9,
+ vs =      -3.8,  -3.8,  -3.8,  -3.8,
+ vmean = -4.
+ umean = -5.
+ case_name='rico'
+ lsvarflg=.false.
+ div=0.00000000
+
+ ! turn on optional features
+ ladvtrc = .true.  ! advected position tracers
+/
+```

--- a/tests/test_uclacles_cli.py
+++ b/tests/test_uclacles_cli.py
@@ -1,0 +1,15 @@
+import tempfile
+from pathlib import Path
+
+import advtraj.cli.uclales
+
+
+def test_uclales_cli(uclales_testdata_path):
+    # TODO: move prefix somewhere else
+    file_prefix = "rico"
+    with tempfile.TemporaryDirectory() as tempdir:
+        advtraj.cli.uclales.main(
+            data_path=uclales_testdata_path,
+            file_prefix=file_prefix,
+            output_path=str(Path(tempdir) / "trajectories.nc"),
+        )


### PR DESCRIPTION
This pull-request adds automatic download of sample UCLALES model output which contains advected scalars, and also adds a test for automatically running the UCLALES cli on this test data.

Related to https://github.com/ParaConUK/advtraj/issues/16