### PR TITLE
Fix pre-commit ci/cd issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,6 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 6.1.0
     hooks:
       - id: flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - add `scipy` to requirements
   [\#26](https://github.com/ParaConUK/advtraj/pull/26) @leifdenby
 
+- fix ci/cd issues with pre-commit linting due to breaking change in flake8 integration
+  [\#30](https://github.com/ParaConUK/advtraj/pull/30) @leifdenby
+
 
 ## [v0.5.1](https://github.com/ParaConUK/advtraj/tree/v0.5.1)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,13 +59,20 @@ testpaths = tests
 
 [flake8]
 ignore =
-    E203 # whitespace before ':' - doesn't work well with black
-    E402 # module level import not at top of file
-    E501 # line too long - let black worry about that
-    E731 # do not assign a lambda expression, use a def
-    W503 # line break before binary operator
-    E741 # ambigious name
-    C901 # function is too complex
+    # whitespace before ':' - doesn't work well with black
+    E203,
+    # module level import not at top of file
+    E402,
+    # line too long - let black worry about that
+    E501,
+    # do not assign a lambda expression, use a def
+    E731,
+    # line break before binary operator
+    W503,
+    # ambigious name
+    E741,
+    # function is too complex
+    C901
 exclude=
     .eggs
     doc


### PR DESCRIPTION
Due to a breaking change in compatibility between flake8 and pre-commit the version of flake8 needed to be increased in the pre-commit config. This newer version has stricter formatting requirements for setup.cfg which this commit also addresses.