### PR TITLE
req name change sklearn -> scikit-learn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 - fix ci/cd issues with pre-commit linting due to breaking change in flake8 integration
   [\#30](https://github.com/ParaConUK/advtraj/pull/30) @leifdenby
 
+- fix deprecation of requirement package name `sklearn` by instead requiring
+  the new package name `scikit-learn`.
+  [\#31](https://github.com/ParaConUK/advtraj/pull/31) @leifdenby
+
 
 ## [v0.5.1](https://github.com/ParaConUK/advtraj/tree/v0.5.1)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sklearn
+scikit-learn
 numpy
 xarray
 netCDF4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-scikit-learn
-numpy
-xarray
-netCDF4
-numba
-tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.htm
 include_package_data = True
 python_requires = >=3.7
 install_requires =
-    sklearn
+    scikit-learn
     numpy
     scipy
     xarray


### PR DESCRIPTION
Handle issue with referencing scikit-learn package as `sklearn`. That name is now deprecated and the package should be referenced as `scikit-learn`.